### PR TITLE
Optional Java Dependency Appears Broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "semver": "^4.3.3"
   },
   "optionalDependencies": {
-    "java": "^0.5.4"
+    "java": "^0.6.1"
   }
 }


### PR DESCRIPTION
On both OSX and Ubuntu, npm install fails with the (optional) dependency breaking.

This appears to be due to java@0.5.5:

```
> java@0.5.5 install /home/jsanford/node-commit-msg/node_modules/java
> node-gyp rebuild

make: Entering directory `/home/jsanford/node-commit-msg/node_modules/java/build'
  CXX(target) Release/obj.target/nodejavabridge_bindings/src/java.o
In file included from ../node_modules/nan/nan_new.h:190:0,
                 from ../node_modules/nan/nan.h:80,
                 from ../src/java.h:9,
                 from ../src/java.cpp:1:
../node_modules/nan/nan_implementation_12_inl.h: In static member function ‘static NanIntern::FactoryBase<v8::Signature>::return_t NanIntern::Factory<v8::Signature>::New(NanIntern::Factory<v8::Signature>::FTH, int, NanIntern::Factory<v8::Signature>::FTH*)’:
../node_modules/nan/nan_implementation_12_inl.h:181:76: error: no matching function for call to ‘v8::Signature::New(v8::Isolate*, NanIntern::Factory<v8::Signature>::FTH&, int&, NanIntern::Factory<v8::Signature>::FTH*&)’
   return v8::Signature::New(v8::Isolate::GetCurrent(), receiver, argc, argv);
                                                                            ^
../node_modules/nan/nan_implementation_12_inl.h:181:76: note: candidate is:
In file included from ../src/java.h:5:0,
                 from ../src/java.cpp:1:
/home/jsanford/.node-gyp/4.8.1/include/node/v8.h:4675:27: note: static v8::Local<v8::Signature> v8::Signature::New(v8::Isolate*, v8::Local<v8::FunctionTemplate>)
   static Local<Signature> New(
                           ^
/home/jsanford/.node-gyp/4.8.1/include/node/v8.h:4675:27: note:   candidate expects 2 arguments, 4 provided
In file included from ../src/java.h:9:0,
                 from ../src/java.cpp:1:
../node_modules/nan/nan.h: At global scope:
../node_modules/nan/nan.h:171:25: error: redefinition of ‘template<class T> v8::Local<T> _NanEnsureLocal(v8::Local<T>)’
 NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
                         ^
../node_modules/nan/nan.h:166:25: error: ‘template<class T> v8::Local<T> _NanEnsureLocal(v8::Handle<T>)’ previously declared here
 NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Handle<T> val) {
                         ^
../node_modules/nan/nan.h:564:13: error: ‘node::smalloc’ has not been declared
     , node::smalloc::FreeCallback callback
             ^
../node_modules/nan/nan.h:564:35: error: expected ‘,’ or ‘...’ before ‘callback’
     , node::smalloc::FreeCallback callback
                                   ^
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanNewBufferHandle(char*, size_t, int)’:
../node_modules/nan/nan.h:568:50: error: ‘callback’ was not declared in this scope
         v8::Isolate::GetCurrent(), data, length, callback, hint);
                                                  ^
../node_modules/nan/nan.h:568:60: error: ‘hint’ was not declared in this scope
         v8::Isolate::GetCurrent(), data, length, callback, hint);
                                                            ^
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanNewBufferHandle(const char*, uint32_t)’:
../node_modules/nan/nan.h:575:67: error: call of overloaded ‘New(v8::Isolate*, const char*&, uint32_t&)’ is ambiguous
     return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
                                                                   ^
../node_modules/nan/nan.h:575:67: note: candidates are:
In file included from ../node_modules/nan/nan.h:25:0,
                 from ../src/java.h:9,
                 from ../src/java.cpp:1:
/home/jsanford/.node-gyp/4.8.1/include/node/node_buffer.h:34:40: note: v8::MaybeLocal<v8::Object> node::Buffer::New(v8::Isolate*, v8::Local<v8::String>, node::encoding) <near match>
 NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                        ^
/home/jsanford/.node-gyp/4.8.1/include/node/node_buffer.h:34:40: note:   no known conversion for argument 3 from ‘uint32_t {aka unsigned int}’ to ‘node::encoding’
/home/jsanford/.node-gyp/4.8.1/include/node/node_buffer.h:46:40: note: v8::MaybeLocal<v8::Object> node::Buffer::New(v8::Isolate*, char*, size_t) <near match>
 NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                        ^
/home/jsanford/.node-gyp/4.8.1/include/node/node_buffer.h:46:40: note:   no known conversion for argument 2 from ‘const char*’ to ‘char*’
In file included from ../src/java.h:9:0,
                 from ../src/java.cpp:1:
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanNewBufferHandle(uint32_t)’:
../node_modules/nan/nan.h:579:61: error: could not convert ‘node::Buffer::New(v8::Isolate::GetCurrent(), ((size_t)size))’ from ‘v8::MaybeLocal<v8::Object>’ to ‘v8::Local<v8::Object>’
     return node::Buffer::New(v8::Isolate::GetCurrent(), size);
                                                             ^
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanBufferUse(char*, uint32_t)’:
../node_modules/nan/nan.h:586:12: error: ‘Use’ is not a member of ‘node::Buffer’
     return node::Buffer::Use(v8::Isolate::GetCurrent(), data, size);
            ^
make: *** [Release/obj.target/nodejavabridge_bindings/src/java.o] Error 1
make: Leaving directory `/home/jsanford/node-commit-msg/node_modules/java/build'
```

I have updated as little as possible here, pushing to **0.6** branch. **0.8** is current, but I don't want to be presumptuous.

Discussed elsewhere:
https://github.com/joeferner/node-java/issues/250

Thanks, we leverage this module a lot.